### PR TITLE
Fix bug in PBKW test.

### DIFF
--- a/tests/KAT/LocalPWTest.php
+++ b/tests/KAT/LocalPWTest.php
@@ -51,7 +51,7 @@ class LocalPWTest extends KnownAnswers
     {
         foreach ($tests as $test) {
             $wrapper = new LocalPW(
-                new HiddenString(Hex::encode($test['password'])),
+                new HiddenString($test['password']),
                 $test['options'] ?? []
             );
             $unwrapped = $wrapper->decode($test['paserk']);

--- a/tests/KAT/SecretPWTest.php
+++ b/tests/KAT/SecretPWTest.php
@@ -52,7 +52,7 @@ class SecretPWTest extends KnownAnswers
     {
         foreach ($tests as $test) {
             $wrapper = new SecretPW(
-                new HiddenString(Hex::encode($test['password'])),
+                new HiddenString($test['password']),
                 $test['options'] ?? []
             );
             $unwrapped = $wrapper->decode($test['paserk']);


### PR DESCRIPTION
I think that it is something like a typo but "password" for PBKW does not need to be converted to hex string.