### PR TITLE
Fix bug in v3.seal.

### DIFF
--- a/src/Operations/PKE/PKEv3.php
+++ b/src/Operations/PKE/PKEv3.php
@@ -67,7 +67,7 @@ class PKEv3 implements PKEInterface
         // Step 4:
         $Ak = hash(
             'sha384',
-            "\x01" . $header . $xk . $eph_pk_compressed . $pk_compressed,
+            "\x02" . $header . $xk . $eph_pk_compressed . $pk_compressed,
             true
         );
 
@@ -137,7 +137,7 @@ class PKEv3 implements PKEInterface
         // Step 2:
         $Ak = hash(
             'sha384',
-            "\x01" . $header . $xk . $eph_pk_compressed . $pk_compressed,
+            "\x02" . $header . $xk . $eph_pk_compressed . $pk_compressed,
             true
         );
 


### PR DESCRIPTION
It seems that the v3.seal implementation does not follow [the spec for PKE](https://github.com/paseto-standard/paserk/blob/master/operations/PKE.md). As a result of it, the generated authentication key and encryption key have the same value.